### PR TITLE
Fix: do not allocate a Vec to iterate over CfgEdge nodes

### DIFF
--- a/lib/relooper/src/graph/supergraph.rs
+++ b/lib/relooper/src/graph/supergraph.rs
@@ -202,7 +202,7 @@ impl<TLabel: CfgLabel + Debug> SuperGraph<TLabel> {
                 .contained
                 .iter()
                 .map(|&l| (l, *self.cfg.edge(&l)))
-                .filter(|(_l, e)| e.to_vec().into_iter().any(|&to| to == split_snode.head))
+                .filter(|(_l, e)| e.iter().any(|&to| to == split_snode.head))
                 .collect();
 
             for (f, e) in from_split {


### PR DESCRIPTION
Resolves the `todo unncecessary collect` in `lib/relooper/src/graph/cfg/mod.rs`.

The issue there was that the `filter` call takes a closure that captures the borrow on `self` which then prevents us from borrowing self to insert the node in the body of the loop. So here I have replaced the call to `filter` with a simple `if` statement that does the same thing. I also directly borrowed `out_edges` to avoid multiple borrows on `self` (this is also more efficient because it saves us from building the `HashSet`).

While I was at it, I replaced the `to_vec` implementation on `CfgEdge` with something else that does the same job (creates an iterator over the nodes of the edge), but avoids the heap allocation.