### PR TITLE
dfs-postorder unified for hash & ord

### DIFF
--- a/lib/relooper/src/graph/enrichments.rs
+++ b/lib/relooper/src/graph/enrichments.rs
@@ -1,6 +1,6 @@
 use crate::graph::cfg::{Cfg, CfgEdge, CfgLabel};
 use crate::traversal::graph::bfs::Bfs;
-use crate::traversal::graph::dfs::{dfs_post_hashable, Dfs};
+use crate::traversal::graph::dfs::{Dfs, DfsPost, DfsPostReverseInstantiator};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::vec::Vec;
 
@@ -171,7 +171,8 @@ pub struct NodeOrdering<TLabel: CfgLabel> {
 
 impl<TLabel: CfgLabel> NodeOrdering<TLabel> {
     pub fn new(cfg: &Cfg<TLabel>, entry: TLabel) -> Self {
-        let vec = dfs_post_hashable(entry, |x| cfg.children(x).into_iter().copied());
+        let vec =
+            DfsPost::<_, _, HashSet<_>>::reverse(entry, |x| cfg.children(x).into_iter().copied());
         let idx: HashMap<TLabel, usize> = vec.iter().enumerate().map(|(i, &n)| (n, i)).collect();
         Self { vec, idx }
     }

--- a/lib/relooper/src/graph/supergraph.rs
+++ b/lib/relooper/src/graph/supergraph.rs
@@ -117,7 +117,7 @@ impl<TLabel: CfgLabel + Debug> SuperGraph<TLabel> {
     /// We are using that order for traversing supernodes graph for choosing between merge/split actions
     fn snode_order(&self) -> Vec<SLabel<TLabel>> {
         let start = self.nodes.get(&self.cfg.entry).unwrap().clone();
-        let res: Vec<_> = DfsPost::<_, _, HashSet<_>>::reverse(start.head, |slabel| {
+        DfsPost::<_, _, HashSet<_>>::reverse(start.head, |slabel| {
             let snode = self.nodes.get(slabel).unwrap();
             snode.contained.iter().flat_map(|l| {
                 self.cfg
@@ -126,9 +126,6 @@ impl<TLabel: CfgLabel + Debug> SuperGraph<TLabel> {
                     .map(|to| *self.label_location.get(to).unwrap())
             })
         })
-        .into_iter()
-        .collect();
-        res
     }
 
     /// finding out applicable action for given supernode

--- a/lib/relooper/src/graph/supergraph.rs
+++ b/lib/relooper/src/graph/supergraph.rs
@@ -1,7 +1,7 @@
 use crate::graph::cfg::CfgEdge::{Cond, Terminal, Uncond};
 use crate::graph::cfg::{Cfg, CfgEdge, CfgLabel};
 use crate::graph::supergraph::NodeAction::{MergeInto, SplitFor};
-use crate::traversal::graph::dfs::dfs_post_comparable;
+use crate::traversal::graph::dfs::{DfsPost, DfsPostReverseInstantiator};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::{Debug, Display, Formatter};
 
@@ -117,7 +117,7 @@ impl<TLabel: CfgLabel + Debug> SuperGraph<TLabel> {
     /// We are using that order for traversing supernodes graph for choosing between merge/split actions
     fn snode_order(&self) -> Vec<SLabel<TLabel>> {
         let start = self.nodes.get(&self.cfg.entry).unwrap().clone();
-        let res: Vec<_> = dfs_post_comparable(start.head, |slabel| {
+        let res: Vec<_> = DfsPost::<_, _, HashSet<_>>::reverse(start.head, |slabel| {
             let snode = self.nodes.get(slabel).unwrap();
             snode.contained.iter().flat_map(|l| {
                 self.cfg


### PR DESCRIPTION
I spent some time trying to get rid of two functions for the same thing (`dfs_post_hashable`, `dfs_post_comparable`)
they existed because of absence of common trait for HashSet & BTreeSet. so if you want to use some kind of set just to remember visited objects, you should either use one of `Hash` or `Ord` constraints everywhere (which is not always possible), or have two functions doing semantically the same thing
unfortunately (or maybe fortunately? =) ), after I worked around rust type system to kind of achieve what I wanted, I noted that both `Hash` and `BTree` versions is now applicable for both uses as for today (at some point, use in supergraph weren't `Hash`, only `Ord` due to use of `HashSet`s inside of nodes we wanted to operate on)

so, main question: does that change worth it? can/should it be simplified?