### PR TITLE
replace parity_wasm

### DIFF
--- a/bin/evm2near/Cargo.toml
+++ b/bin/evm2near/Cargo.toml
@@ -16,7 +16,6 @@ clap = { version = "3.2.17", features = ["color", "derive", "unicode"] }
 ethnum = "1.2.2"
 evm_rs = "0.3.2"
 hex = "0.4.3"
-parity-wasm = "0.45.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 sha3 = "0.10"

--- a/bin/evm2near/Cargo.toml
+++ b/bin/evm2near/Cargo.toml
@@ -21,6 +21,9 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 sha3 = "0.10"
 wild = "2.1.0"
+wasmparser = "0.102.0"
+wasm-encoder = "0.25.0"
+anyhow = "1.0"
 
 [[bin]]
 name = "evm2near"

--- a/bin/evm2near/src/compile.rs
+++ b/bin/evm2near/src/compile.rs
@@ -145,13 +145,13 @@ impl<'a> Compiler<'a> {
     }
 
     /// Emit an empty `_start` function to make all WebAssembly runtimes happy.
-    fn emit_wasm_start(self: &mut Compiler<'a>) {
+    fn emit_wasm_start(&mut self) {
         _ = self.emit_function(Some("_start".to_string()), vec![]);
     }
 
     /// Synthesizes a start function that initializes the EVM state with the
     /// correct configuration.
-    fn emit_evm_start(self: &mut Compiler<'a>) {
+    fn emit_evm_start(&mut self) {
         assert_ne!(self.evm_init_function, 0);
 
         self.evm_start_function = self.emit_function(
@@ -165,7 +165,7 @@ impl<'a> Compiler<'a> {
         );
     }
 
-    fn emit_abi_execute(self: &mut Compiler<'a>) {
+    fn emit_abi_execute(&mut self) {
         assert_ne!(self.evm_start_function, 0);
         assert_ne!(self.evm_exec_function, 0); // filled in during compile_cfg()
 
@@ -185,7 +185,7 @@ impl<'a> Compiler<'a> {
     /// contract's ABI, enabling users to directly call a contract method
     /// without going through the low-level `execute` EVM dispatcher.
     pub fn emit_abi_methods(
-        self: &mut Compiler<'a>,
+        &mut self,
         input_abi: Option<Functions>,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         assert_ne!(self.evm_start_function, 0);
@@ -478,7 +478,7 @@ subgraph cluster_wasm {{ label = \"wasm\"
     }
 
     /// Compiles the program's control-flow graph.
-    fn compile_cfg(self: &mut Compiler<'a>, program: &'a Program) {
+    fn compile_cfg(&mut self, program: &'a Program) {
         assert_ne!(self.evm_start_function, 0); // filled in during emit_start()
         assert_eq!(self.evm_exec_function, 0); // filled in below
 

--- a/bin/evm2near/src/compile.rs
+++ b/bin/evm2near/src/compile.rs
@@ -19,7 +19,7 @@ use crate::{
     analyze::{basic_cfg, BasicCfg, CfgNode, Idx, Offs},
     config::CompilerConfig,
     encode::encode_push,
-    wasm_translate::{DataMode, Export, ModuleBuilder, Signature},
+    wasm_translate::{translator::DataMode, Export, ModuleBuilder, Signature},
 };
 
 const TABLE_OFFSET: i32 = 0x1000;

--- a/bin/evm2near/src/compile.rs
+++ b/bin/evm2near/src/compile.rs
@@ -73,10 +73,6 @@ pub fn compile<'a>(
     compiler.emit_abi_execute();
     let abi_data = compiler.emit_abi_methods(input_abi).unwrap();
 
-    let table = compiler.builder.tables.get_mut(0).unwrap();
-    table.minimum = 0xFFFF; // grow the table to 65,535 elements
-    table.maximum = Some(0xFFFF);
-
     let abi_buffer_ptr: usize = compiler.abi_buffer_off.try_into().unwrap();
     for data in compiler.builder.data.iter_mut() {
         let min_ptr: usize = match data.mode {

--- a/bin/evm2near/src/compile.rs
+++ b/bin/evm2near/src/compile.rs
@@ -590,7 +590,6 @@ fn make_op_table(module: &ModuleBuilder) -> HashMap<Opcode, FunctionIndex> {
                 },
             }
         }
-        continue;
     }
     result
 }
@@ -607,7 +606,6 @@ fn find_runtime_function(module: &ModuleBuilder, func_name: &str) -> Option<Func
                 return Some(*index);
             }
         }
-        continue;
     }
     None // not found
 }
@@ -628,7 +626,6 @@ fn find_abi_buffer(module: &ModuleBuilder) -> Option<DataOffset> {
                 }
             }
         }
-        continue;
     }
     None // not found
 }

--- a/bin/evm2near/src/compile.rs
+++ b/bin/evm2near/src/compile.rs
@@ -73,8 +73,6 @@ pub fn compile<'a>(
     compiler.emit_abi_execute();
     let abi_data = compiler.emit_abi_methods(input_abi).unwrap();
 
-    let mut output_module = compiler.builder.build();
-
     // TODO RESTORE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     // let tables = output_module.table_section_mut().unwrap().entries_mut();
     // tables[0] = TableType::new(0xFFFF, Some(0xFFFF)); // grow the table to 65,535 elements
@@ -97,7 +95,7 @@ pub fn compile<'a>(
     //         break; // found it
     //     }
     // }
-    output_module
+    compiler.builder.build()
 }
 
 type DataOffset = i32;
@@ -562,14 +560,14 @@ subgraph cluster_wasm {{ label = \"wasm\"
             func_body.instruction(&instr);
         }
 
-        let func_idx = self.builder.add_function(func_sig, func_body);
+        let imports_len = u32::try_from(self.builder.imports.len()).unwrap();
+        let func_idx = self.builder.add_function(func_sig, func_body) + imports_len;
 
         if let Some(name) = name {
-            let imports_len = u32::try_from(self.builder.imports.len()).unwrap();
             let func_export = Export {
                 name,
                 kind: ExportKind::Func,
-                index: func_idx + imports_len,
+                index: func_idx,
             };
             let _ = self.builder.add_export(func_export);
         }

--- a/bin/evm2near/src/compile.rs
+++ b/bin/evm2near/src/compile.rs
@@ -358,8 +358,8 @@ impl<'a> Compiler<'a> {
 
                     res.push(Instruction::Block(BlockType::Empty));
                     res.push(Instruction::Call(self.evm_pop_function));
-                    let l_l = Box::leak(Box::new(linear_table)); // TODO DIRTY HACK
-                    let br_table = Instruction::BrTable(Cow::Borrowed(l_l.as_slice()), 0);
+                    let cow = Cow::Owned(linear_table);
+                    let br_table = Instruction::BrTable(cow, 0);
                     res.push(br_table);
                     res.push(Instruction::End);
                     res.push(Instruction::Unreachable);

--- a/bin/evm2near/src/compile.rs
+++ b/bin/evm2near/src/compile.rs
@@ -1,6 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     convert::TryInto,
     fmt::Display,
@@ -9,22 +10,16 @@ use std::{
 };
 
 use evm_rs::{parse_opcode, Opcode, Program};
-use parity_wasm::{
-    builder::{FunctionBuilder, ModuleBuilder, SignatureBuilder},
-    elements::{
-        BlockType, BrTableData, ExportEntry, FuncBody, ImportCountType, Instruction, Instructions,
-        Internal, Local, Module, TableType, ValueType,
-    },
-};
 use relooper::graph::{enrichments::EnrichedCfg, relooper::ReBlock, supergraph::reduce};
 use relooper::graph::{relooper::ReSeq, supergraph::SLabel};
-use wasm_encoder::ExportKind;
+use wasm_encoder::{BlockType, ExportKind, Function, Instruction, Module, ValType};
 
 use crate::{
     abi::Functions,
     analyze::{basic_cfg, BasicCfg, CfgNode, Idx, Offs},
     config::CompilerConfig,
     encode::encode_push,
+    wasm_translate::{Export, ModuleBuilder, Signature},
 };
 
 const TABLE_OFFSET: i32 = 0x1000;
@@ -65,10 +60,10 @@ fn evm_idx_to_offs(program: &Program) -> HashMap<Idx, Offs> {
     idx2offs
 }
 
-pub fn compile(
-    input_program: &Program,
+pub fn compile<'a>(
+    input_program: &'a Program,
     input_abi: Option<Functions>,
-    runtime_library: Module,
+    runtime_library: ModuleBuilder<'a>,
     config: CompilerConfig,
 ) -> Module {
     let mut compiler = Compiler::new(runtime_library, config);
@@ -80,34 +75,35 @@ pub fn compile(
 
     let mut output_module = compiler.builder.build();
 
-    let tables = output_module.table_section_mut().unwrap().entries_mut();
-    tables[0] = TableType::new(0xFFFF, Some(0xFFFF)); // grow the table to 65,535 elements
+    // TODO RESTORE!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // let tables = output_module.table_section_mut().unwrap().entries_mut();
+    // tables[0] = TableType::new(0xFFFF, Some(0xFFFF)); // grow the table to 65,535 elements
 
-    // Overwrite the `_abi_buffer` data segment in evmlib with the ABI data
-    // (function parameter names and types) for all public Solidity contract
-    // methods:
-    let abi_buffer_ptr: usize = compiler.abi_buffer_off.try_into().unwrap();
-    for data in output_module.data_section_mut().unwrap().entries_mut() {
-        let min_ptr: usize = match data.offset().as_ref().unwrap().code() {
-            [Instruction::I32Const(off), Instruction::End] => (*off).try_into().unwrap(),
-            _ => continue, // skip any nonstandard data segments
-        };
-        let max_ptr: usize = min_ptr + data.value().len();
-        if abi_buffer_ptr >= min_ptr && abi_buffer_ptr < max_ptr {
-            let min_off = abi_buffer_ptr - min_ptr;
-            let max_off = min_off + abi_data.len();
-            assert!(min_ptr + max_off <= max_ptr);
-            data.value_mut()[min_off..max_off].copy_from_slice(&abi_data);
-            break; // found it
-        }
-    }
+    // // Overwrite the `_abi_buffer` data segment in evmlib with the ABI data
+    // // (function parameter names and types) for all public Solidity contract
+    // // methods:
+    // let abi_buffer_ptr: usize = compiler.abi_buffer_off.try_into().unwrap();
+    // for data in output_module.data_section_mut().unwrap().entries_mut() {
+    //     let min_ptr: usize = match data.offset().as_ref().unwrap().code() {
+    //         [Instruction::I32Const(off), Instruction::End] => (*off).try_into().unwrap(),
+    //         _ => continue, // skip any nonstandard data segments
+    //     };
+    //     let max_ptr: usize = min_ptr + data.value().len();
+    //     if abi_buffer_ptr >= min_ptr && abi_buffer_ptr < max_ptr {
+    //         let min_off = abi_buffer_ptr - min_ptr;
+    //         let max_off = min_off + abi_data.len();
+    //         assert!(min_ptr + max_off <= max_ptr);
+    //         data.value_mut()[min_off..max_off].copy_from_slice(&abi_data);
+    //         break; // found it
+    //     }
+    // }
     output_module
 }
 
 type DataOffset = i32;
 type FunctionIndex = u32;
 
-struct Compiler {
+struct Compiler<'a> {
     config: CompilerConfig,
     abi_buffer_off: DataOffset,
     abi_buffer_len: usize,
@@ -120,13 +116,13 @@ struct Compiler {
     evm_pop_function: FunctionIndex,       // _evm_pop_u32
     evm_burn_gas: FunctionIndex,           // _evm_burn_gas
     evm_pc_function: FunctionIndex,        // _evm_set_pc
-    function_import_count: usize,
-    builder: ModuleBuilder,
+    // function_import_count: usize,
+    builder: ModuleBuilder<'a>,
 }
 
-impl Compiler {
+impl<'a> Compiler<'a> {
     /// Instantiates a new compiler state.
-    fn new(runtime_library: Module, config: CompilerConfig) -> Compiler {
+    fn new(runtime_library: ModuleBuilder, config: CompilerConfig) -> Compiler {
         Compiler {
             config,
             abi_buffer_off: find_abi_buffer(&runtime_library).unwrap(),
@@ -141,8 +137,8 @@ impl Compiler {
             evm_pop_function: find_runtime_function(&runtime_library, "_evm_pop_u32").unwrap(),
             evm_burn_gas: find_runtime_function(&runtime_library, "_evm_burn_gas").unwrap(),
             evm_pc_function: find_runtime_function(&runtime_library, "_evm_set_pc").unwrap(),
-            function_import_count: runtime_library.import_count(ImportCountType::Function),
-            builder: parity_wasm::builder::from_module(runtime_library),
+            // function_import_count: runtime_library.import_count(ImportCountType::Function),
+            builder: runtime_library,
         }
     }
 
@@ -156,13 +152,13 @@ impl Compiler {
     }
 
     /// Emit an empty `_start` function to make all WebAssembly runtimes happy.
-    fn emit_wasm_start(self: &mut Compiler) {
+    fn emit_wasm_start(self: &mut Compiler<'a>) {
         _ = self.emit_function(Some("_start".to_string()), vec![]);
     }
 
     /// Synthesizes a start function that initializes the EVM state with the
     /// correct configuration.
-    fn emit_evm_start(self: &mut Compiler) {
+    fn emit_evm_start(self: &mut Compiler<'a>) {
         assert_ne!(self.evm_init_function, 0);
 
         self.evm_start_function = self.emit_function(
@@ -176,7 +172,7 @@ impl Compiler {
         );
     }
 
-    fn emit_abi_execute(self: &mut Compiler) {
+    fn emit_abi_execute(self: &mut Compiler<'a>) {
         assert_ne!(self.evm_start_function, 0);
         assert_ne!(self.evm_exec_function, 0); // filled in during compile_cfg()
 
@@ -196,7 +192,7 @@ impl Compiler {
     /// contract's ABI, enabling users to directly call a contract method
     /// without going through the low-level `execute` EVM dispatcher.
     pub fn emit_abi_methods(
-        self: &mut Compiler,
+        self: &mut Compiler<'a>,
         input_abi: Option<Functions>,
     ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
         assert_ne!(self.evm_start_function, 0);
@@ -264,26 +260,26 @@ impl Compiler {
     //TODO self is only used for `evm_pop_function`
     fn unfold_cfg(
         &self,
-        program: &Program,
+        program: &'a Program,
         cfg_part: &ReSeq<SLabel<CfgNode<EvmBlock>>>,
-        res: &mut Vec<Instruction>,
+        res: &mut Vec<Instruction<'a>>,
         wasm_idx2evm_idx: &mut HashMap<Idx, Idx>,
     ) {
         for block in cfg_part.0.iter() {
             match block {
                 ReBlock::Block(inner_seq) => {
-                    res.push(Instruction::Block(BlockType::NoResult));
+                    res.push(Instruction::Block(BlockType::Empty));
                     self.unfold_cfg(program, inner_seq, res, wasm_idx2evm_idx);
                     res.push(Instruction::End);
                 }
                 ReBlock::Loop(inner_seq) => {
-                    res.push(Instruction::Loop(BlockType::NoResult));
+                    res.push(Instruction::Loop(BlockType::Empty));
                     self.unfold_cfg(program, inner_seq, res, wasm_idx2evm_idx);
                     res.push(Instruction::End);
                 }
                 ReBlock::If(true_branch, false_branch) => {
                     res.push(Instruction::Call(self.evm_pop_function));
-                    res.push(Instruction::If(BlockType::NoResult));
+                    res.push(Instruction::If(BlockType::Empty));
                     self.unfold_cfg(program, true_branch, res, wasm_idx2evm_idx);
                     res.push(Instruction::Else);
                     self.unfold_cfg(program, false_branch, res, wasm_idx2evm_idx);
@@ -367,12 +363,10 @@ impl Compiler {
                         linear_table[cond] = br_num + 1; // increment due to additional block wrapping (for unreachable instruction)
                     }
 
-                    res.push(Instruction::Block(BlockType::NoResult));
+                    res.push(Instruction::Block(BlockType::Empty));
                     res.push(Instruction::Call(self.evm_pop_function));
-                    let br_table = Instruction::BrTable(Box::new(BrTableData {
-                        table: linear_table.into_boxed_slice(),
-                        default: 0,
-                    }));
+                    let l_l = Box::leak(Box::new(linear_table)); // TODO DIRTY HACK
+                    let br_table = Instruction::BrTable(Cow::Borrowed(l_l.as_slice()), 0);
                     res.push(br_table);
                     res.push(Instruction::End);
                     res.push(Instruction::Unreachable);
@@ -443,7 +437,7 @@ impl Compiler {
         let wasm_nodes: Vec<_> = wasm
             .iter()
             .enumerate()
-            .map(|(idx, w_op)| format!("wasm_{}[label=\"{}\"];", idx, w_op))
+            .map(|(idx, w_op)| format!("wasm_{}[label=\"{:?}\"];", idx, w_op))
             .collect();
 
         let wasm_seq_links: Vec<_> = (0..wasm.len())
@@ -491,7 +485,7 @@ subgraph cluster_wasm {{ label = \"wasm\"
     }
 
     /// Compiles the program's control-flow graph.
-    fn compile_cfg(self: &mut Compiler, program: &Program) {
+    fn compile_cfg(self: &mut Compiler<'a>, program: &'a Program) {
         assert_ne!(self.evm_start_function, 0); // filled in during emit_start()
         assert_eq!(self.evm_exec_function, 0); // filled in below
 
@@ -546,7 +540,7 @@ subgraph cluster_wasm {{ label = \"wasm\"
     }
 
     /// Compiles the invocation of an EVM operator (operands must be already pushed).
-    fn compile_operator(&self, op: &Opcode) -> Instruction {
+    fn compile_operator(&self, op: &Opcode) -> Instruction<'a> {
         let op = op.zeroed();
         let op_idx = self.op_table.get(&op).unwrap();
         Instruction::Call(*op_idx)
@@ -558,72 +552,59 @@ subgraph cluster_wasm {{ label = \"wasm\"
             Some(_) | None => code.push(Instruction::End),
         };
 
-        let func_sig = SignatureBuilder::new()
-            .with_params(vec![])
-            .with_results(vec![])
-            .build_sig();
+        let func_sig = Signature {
+            params: vec![],
+            results: vec![],
+        };
 
-        let func_locals = vec![Local::new(1, ValueType::I32)]; // needed for dynamic branches
-        let func_body = FuncBody::new(func_locals, Instructions::new(code));
+        let mut func_body = Function::new_with_locals_types(vec![ValType::I32]);
+        for instr in code {
+            func_body.instruction(&instr);
+        }
 
-        let func = FunctionBuilder::new()
-            .with_signature(func_sig)
-            .with_body(func_body)
-            .build();
-
-        let func_loc = self.builder.push_function(func);
-
-        let func_idx = func_loc.signature + self.function_import_count as u32; // TODO: https://github.com/paritytech/parity-wasm/issues/304
+        let func_idx = self.builder.add_function(func_sig, func_body);
 
         if let Some(name) = name {
-            let func_export = ExportEntry::new(name, Internal::Function(func_idx));
-
-            let _ = self.builder.push_export(func_export);
+            let imports_len = u32::try_from(self.builder.imports.len()).unwrap();
+            let func_export = Export {
+                name,
+                kind: ExportKind::Func,
+                index: func_idx + imports_len,
+            };
+            let _ = self.builder.add_export(func_export);
         }
 
         func_idx
     }
 }
 
-fn make_op_table(module: &Module) -> HashMap<Opcode, FunctionIndex> {
+fn make_op_table(module: &ModuleBuilder) -> HashMap<Opcode, FunctionIndex> {
     let mut result: HashMap<Opcode, FunctionIndex> = HashMap::new();
-    for export in module.export_section().unwrap().entries() {
-        match export.internal() {
-            &Internal::Function(op_idx) => match export.field() {
+    for export in module.exports.iter() {
+        if let Export {
+            name,
+            kind: ExportKind::Func,
+            index,
+        } = export
+        {
+            match name.as_str() {
                 "_abi_buffer" | "_evm_start" | "_evm_init" | "_evm_call" | "_evm_exec"
                 | "_evm_post_exec" | "_evm_pop_u32" | "_evm_push_u32" | "_evm_burn_gas"
                 | "_evm_set_pc" | "execute" => {}
                 export_sym => match parse_opcode(&export_sym.to_ascii_uppercase()) {
                     None => unreachable!(), // TODO
-                    Some(op) => _ = result.insert(op, op_idx),
+                    Some(op) => _ = result.insert(op, *index),
                 },
-            },
-            _ => continue,
+            }
         }
+        continue;
     }
     result
 }
 
-fn find_runtime_function(module: &Module, name: &str) -> Option<FunctionIndex> {
-    for export in module.export_section().unwrap().entries() {
-        match export.internal() {
-            &Internal::Function(op_idx) => {
-                if export.field() == name {
-                    return Some(op_idx);
-                }
-            }
-            _ => continue,
-        }
-    }
-    None // not found
-}
-
-fn find_runtime_function_n(
-    module: &crate::wasm_translate::ModuleBuilder,
-    func_name: &str,
-) -> Option<FunctionIndex> {
+fn find_runtime_function(module: &ModuleBuilder, func_name: &str) -> Option<FunctionIndex> {
     for export in module.exports.iter() {
-        if let crate::wasm_translate::Export {
+        if let Export {
             name,
             kind: ExportKind::Func,
             index,
@@ -638,33 +619,9 @@ fn find_runtime_function_n(
     None // not found
 }
 
-fn find_abi_buffer(module: &Module) -> Option<DataOffset> {
-    for export in module.export_section().unwrap().entries() {
-        match export.internal() {
-            &Internal::Global(idx) => {
-                if export.field() == "_abi_buffer" {
-                    // found it
-                    let global = module
-                        .global_section()
-                        .unwrap()
-                        .entries()
-                        .get(idx as usize)
-                        .unwrap();
-                    match global.init_expr().code().first().unwrap() {
-                        Instruction::I32Const(off) => return Some(*off),
-                        _ => return None,
-                    }
-                }
-            }
-            _ => continue,
-        }
-    }
-    None // not found
-}
-
-fn find_abi_buffer_n(module: &crate::wasm_translate::ModuleBuilder) -> Option<DataOffset> {
+fn find_abi_buffer(module: &ModuleBuilder) -> Option<DataOffset> {
     for export in module.exports.iter() {
-        if let crate::wasm_translate::Export {
+        if let Export {
             name,
             kind: ExportKind::Global,
             index,

--- a/bin/evm2near/src/encode.rs
+++ b/bin/evm2near/src/encode.rs
@@ -1,7 +1,7 @@
 // This is free and unencumbered software released into the public domain.
 
 use evm_rs::Opcode;
-use parity_wasm::elements::Instruction;
+use wasm_encoder::Instruction;
 
 pub fn encode_push(op: &Opcode) -> Vec<Instruction> {
     let mut result = vec![];

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -178,8 +178,7 @@ fn main() -> impl std::process::Termination {
         OutputABI::Wasi => runtime_wasi.to_vec(),
     };
 
-    let mut t = wasm_translate::Translator::new();
-    let runtime_library = t.parse(&current_runtime).unwrap();
+    let runtime_library = wasm_translate::parse(&current_runtime).unwrap();
 
     let module = compile(
         &input_program,

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -178,11 +178,9 @@ fn main() -> impl std::process::Termination {
         OutputABI::Near => runtime_wasm.to_vec(),
         OutputABI::Wasi => runtime_wasi.to_vec(),
     };
-    // let r_lib_parsed = wasmparser::Parser::new(0)
-    //     .parse_all(current_runtime.as_slice())
-    //     .map(|p| p.unwrap())
-    //     .collect::<Vec<_>>();
-    // let r_lib = wasm_translate::ty(t, ty)
+
+    let r_lib = wasm_translate::parse(current_runtime.clone()).unwrap();
+
     let runtime_library = parity_wasm::deserialize_buffer(current_runtime.as_slice()).unwrap();
 
     let output_program = compile(

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -178,7 +178,8 @@ fn main() -> impl std::process::Termination {
         OutputABI::Wasi => runtime_wasi.to_vec(),
     };
 
-    let runtime_library = wasm_translate::parse(&current_runtime).unwrap();
+    let mut t = wasm_translate::Translator::new();
+    let runtime_library = t.parse(&current_runtime).unwrap();
 
     let module = compile(
         &input_program,

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -183,7 +183,8 @@ fn main() -> impl std::process::Termination {
     let r_lib_bytes = r_lib.build().finish();
     std::fs::write("r_lib.wasm", r_lib_bytes).expect("fs err");
 
-    let runtime_library = parity_wasm::deserialize_buffer(current_runtime.as_slice()).unwrap();
+    let runtime_library: parity_wasm::elements::Module =
+        parity_wasm::deserialize_buffer(current_runtime.as_slice()).unwrap();
 
     let output_program = compile(
         &input_program,

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -180,7 +180,7 @@ fn main() -> impl std::process::Termination {
     };
 
     let r_lib = wasm_translate::parse(current_runtime.clone()).unwrap();
-    let r_lib_bytes = r_lib.finish();
+    let r_lib_bytes = r_lib.build().finish();
     std::fs::write("r_lib.wasm", r_lib_bytes).expect("fs err");
 
     let runtime_library = parity_wasm::deserialize_buffer(current_runtime.as_slice()).unwrap();

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -180,6 +180,8 @@ fn main() -> impl std::process::Termination {
     };
 
     let r_lib = wasm_translate::parse(current_runtime.clone()).unwrap();
+    let r_lib_bytes = r_lib.finish();
+    std::fs::write("r_lib.wasm", r_lib_bytes).expect("fs err");
 
     let runtime_library = parity_wasm::deserialize_buffer(current_runtime.as_slice()).unwrap();
 

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -181,7 +181,7 @@ fn main() -> impl std::process::Termination {
     let runtime_library = wasm_translate::parse(&current_runtime).unwrap();
 
     let module = compile(
-        Box::leak(Box::new(input_program)),
+        &input_program,
         input_abi,
         runtime_library,
         CompilerConfig::new(

--- a/bin/evm2near/src/main.rs
+++ b/bin/evm2near/src/main.rs
@@ -11,6 +11,7 @@ mod encode;
 mod error;
 mod format;
 mod solidity;
+mod wasm_translate;
 
 use clap::Parser;
 use parity_wasm::elements::Serialize;
@@ -173,11 +174,16 @@ fn main() -> impl std::process::Termination {
 
     let runtime_wasm = include_bytes!("../../../evmlib.wasm");
     let runtime_wasi = include_bytes!("../../../evmlib.wasi");
-    let runtime_library = parity_wasm::deserialize_buffer(match options.abi {
-        OutputABI::Near => runtime_wasm,
-        OutputABI::Wasi => runtime_wasi,
-    })
-    .unwrap();
+    let current_runtime = match options.abi {
+        OutputABI::Near => runtime_wasm.to_vec(),
+        OutputABI::Wasi => runtime_wasi.to_vec(),
+    };
+    // let r_lib_parsed = wasmparser::Parser::new(0)
+    //     .parse_all(current_runtime.as_slice())
+    //     .map(|p| p.unwrap())
+    //     .collect::<Vec<_>>();
+    // let r_lib = wasm_translate::ty(t, ty)
+    let runtime_library = parity_wasm::deserialize_buffer(current_runtime.as_slice()).unwrap();
 
     let output_program = compile(
         &input_program,

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -77,7 +77,6 @@ impl<'a> ModuleBuilder<'a> {
         self.code.push(body);
         let code_id = u32::try_from(self.code.len()).unwrap() - 1;
         assert_eq!(sig_id, code_id);
-        println!("added function with type id {type_idx}, func id {sig_id}");
         sig_id
     }
 

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -168,7 +168,6 @@ impl<'a> ModuleBuilder<'a> {
                 } => {
                     let mut instr_buf = vec![];
                     offset.encode(&mut instr_buf);
-                    Instruction::End.encode(&mut instr_buf);
                     let expr = Box::leak(Box::new(ConstExpr::raw(instr_buf)));
                     DataSegmentMode::Active {
                         memory_index,

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -249,7 +249,8 @@ pub fn parse(wasm: &Vec<u8>) -> Result<ModuleBuilder> {
                 for tag in tag_section {
                     let tag = tag?;
                     let _tag_type = tag_type(&tag)?;
-                    panic!("unspecified section (spec doesnt have that one! WTF)");
+                    panic!("only wasm core - 1 specification is supported by near runtime");
+                    // https://github.com/near/nearcore/issues/8358#issuecomment-1383247423
                 }
             }
             Payload::GlobalSection(global_section) => {
@@ -285,7 +286,8 @@ pub fn parse(wasm: &Vec<u8>) -> Result<ModuleBuilder> {
                 }
             }
             Payload::DataCountSection { count: _, range: _ } => {
-                panic!("unspecified section (spec doesnt have that one! WTF)");
+                panic!("only wasm core - 1 specification is supported by near runtime");
+                // https://github.com/near/nearcore/issues/8358#issuecomment-1383247423
             }
             Payload::DataSection(data_section) => {
                 for d in data_section {

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -9,11 +9,14 @@ use wasmparser::{
 
 pub type Params = Vec<ValType>;
 pub type Results = Vec<ValType>;
+
+#[derive(Debug)]
 pub struct Signature {
     pub params: Params,
     pub results: Results,
 }
 
+#[derive(Debug)]
 pub struct Import {
     module: String,
     field: String,
@@ -22,18 +25,21 @@ pub struct Import {
 
 pub type TypeIndex = u32;
 
+#[derive(Debug)]
 pub struct Glob<'a> {
     //todo rename
     pub typ: GlobalType,
     pub init_instr: Instruction<'a>,
 }
 
+#[derive(Debug)]
 pub struct Export {
     pub name: String,
     pub kind: ExportKind,
     pub index: u32,
 }
 
+#[derive(Debug)]
 pub enum DataMode<'a> {
     Active {
         memory_index: u32,
@@ -42,11 +48,13 @@ pub enum DataMode<'a> {
     Passive,
 }
 
+#[derive(Debug)]
 pub struct Data<'a> {
     pub mode: DataMode<'a>,
     pub data: Vec<u8>,
 }
 
+#[derive(Debug)]
 pub struct ModuleBuilder<'a> {
     pub types: Vec<Signature>,
     pub imports: Vec<Import>,
@@ -185,7 +193,7 @@ impl<'a> ModuleBuilder<'a> {
     }
 }
 
-pub fn parse<'a>(wasm: &'a Vec<u8>) -> Result<ModuleBuilder<'a>> {
+pub fn parse(wasm: &Vec<u8>) -> Result<ModuleBuilder> {
     let parsed = wasmparser::Parser::new(0)
         .parse_all(wasm.as_slice())
         .map(|p| p.unwrap())
@@ -335,13 +343,11 @@ pub fn parse<'a>(wasm: &'a Vec<u8>) -> Result<ModuleBuilder<'a>> {
     Ok(builder)
 }
 
+// todo remove
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
 pub enum ConstExprKind {
-    Global,
     ElementOffset,
     ElementFunction,
-    DataOffset,
-    TableInit,
 }
 
 pub struct Translator;

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -153,11 +153,21 @@ impl<'a> ModuleBuilder<'a> {
         }
         m.section(&export_section);
 
-        self.start_sect.map(|start_sect| m.section(&start_sect));
+        if let Some(start_sect) = self.start_sect {
+            m.section(&start_sect);
+        }
 
         let mut element_section = ElementSection::new();
         for e in self.elements {
-            element_section.segment(e);
+            let mut modified = e;
+            if let ElementMode::Active {
+                ref mut table,
+                offset: _,
+            } = modified.mode
+            {
+                *table = None; // seems like near runtime does not support multiple tables. at least it definitely does not respect any table indexes there
+            }
+            element_section.segment(modified);
         }
         m.section(&element_section);
 

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -1,0 +1,452 @@
+// grabbed from https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wasm-mutate/src/mutators/translate.rs
+
+use anyhow::{Error, Result};
+use wasm_encoder::*;
+use wasmparser::{DataKind, ElementKind, FunctionBody, Global, Operator, Type};
+
+#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
+pub enum Item {
+    Function,
+    Table,
+    Memory,
+    Tag,
+    Global,
+    Type,
+    Data,
+    Element,
+}
+
+#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
+pub enum ConstExprKind {
+    Global,
+    ElementOffset,
+    ElementFunction,
+    DataOffset,
+    TableInit,
+}
+
+pub trait Translator {
+    fn as_obj(&mut self) -> &mut dyn Translator;
+
+    fn translate_type_def(&mut self, ty: Type, s: &mut TypeSection) -> Result<()> {
+        type_def(self.as_obj(), ty, s)
+    }
+
+    fn translate_table_type(
+        &mut self,
+        ty: &wasmparser::TableType,
+    ) -> Result<wasm_encoder::TableType> {
+        table_type(self.as_obj(), ty)
+    }
+
+    fn translate_memory_type(
+        &mut self,
+        ty: &wasmparser::MemoryType,
+    ) -> Result<wasm_encoder::MemoryType> {
+        memory_type(self.as_obj(), ty)
+    }
+
+    fn translate_global_type(
+        &mut self,
+        ty: &wasmparser::GlobalType,
+    ) -> Result<wasm_encoder::GlobalType> {
+        global_type(self.as_obj(), ty)
+    }
+
+    fn translate_tag_type(&mut self, ty: &wasmparser::TagType) -> Result<wasm_encoder::TagType> {
+        tag_type(self.as_obj(), ty)
+    }
+
+    fn translate_ty(&mut self, t: &wasmparser::ValType) -> Result<ValType> {
+        ty(self.as_obj(), t)
+    }
+
+    fn translate_refty(&mut self, t: &wasmparser::RefType) -> Result<RefType> {
+        refty(self.as_obj(), t)
+    }
+
+    fn translate_heapty(&mut self, t: &wasmparser::HeapType) -> Result<HeapType> {
+        heapty(self.as_obj(), t)
+    }
+
+    fn translate_global(&mut self, g: Global, s: &mut GlobalSection) -> Result<()> {
+        global(self.as_obj(), g, s)
+    }
+
+    fn translate_const_expr(
+        &mut self,
+        e: &wasmparser::ConstExpr<'_>,
+        _ty: &wasmparser::ValType,
+        ctx: ConstExprKind,
+    ) -> Result<wasm_encoder::ConstExpr> {
+        const_expr(self.as_obj(), e, ctx)
+    }
+
+    fn translate_element(
+        &mut self,
+        e: wasmparser::Element<'_>,
+        s: &mut ElementSection,
+    ) -> Result<()> {
+        element(self.as_obj(), e, s)
+    }
+
+    fn translate_data(&mut self, d: wasmparser::Data<'_>, s: &mut DataSection) -> Result<()> {
+        data(self.as_obj(), d, s)
+    }
+
+    fn translate_code(&mut self, body: FunctionBody<'_>, s: &mut CodeSection) -> Result<()> {
+        code(self.as_obj(), body, s)
+    }
+
+    fn translate_op(&mut self, e: &Operator<'_>) -> Result<Instruction<'static>> {
+        op(self.as_obj(), e)
+    }
+
+    fn translate_block_type(&mut self, ty: &wasmparser::BlockType) -> Result<BlockType> {
+        block_type(self.as_obj(), ty)
+    }
+
+    fn translate_memarg(&mut self, arg: &wasmparser::MemArg) -> Result<MemArg> {
+        memarg(self.as_obj(), arg)
+    }
+
+    fn remap(&mut self, item: Item, idx: u32) -> Result<u32> {
+        // drop(item);
+        Ok(idx)
+    }
+}
+
+pub struct DefaultTranslator;
+
+impl Translator for DefaultTranslator {
+    fn as_obj(&mut self) -> &mut dyn Translator {
+        self
+    }
+}
+
+pub fn type_def(t: &mut dyn Translator, ty: Type, s: &mut TypeSection) -> Result<()> {
+    match ty {
+        Type::Func(f) => {
+            s.function(
+                f.params()
+                    .iter()
+                    .map(|ty| t.translate_ty(ty))
+                    .collect::<Result<Vec<_>>>()?,
+                f.results()
+                    .iter()
+                    .map(|ty| t.translate_ty(ty))
+                    .collect::<Result<Vec<_>>>()?,
+            );
+            Ok(())
+        }
+    }
+}
+
+pub fn table_type(
+    t: &mut dyn Translator,
+    ty: &wasmparser::TableType,
+) -> Result<wasm_encoder::TableType> {
+    Ok(wasm_encoder::TableType {
+        element_type: t.translate_refty(&ty.element_type)?,
+        minimum: ty.initial,
+        maximum: ty.maximum,
+    })
+}
+
+pub fn memory_type(
+    _t: &mut dyn Translator,
+    ty: &wasmparser::MemoryType,
+) -> Result<wasm_encoder::MemoryType> {
+    Ok(wasm_encoder::MemoryType {
+        memory64: ty.memory64,
+        minimum: ty.initial,
+        maximum: ty.maximum,
+        shared: ty.shared,
+    })
+}
+
+pub fn global_type(
+    t: &mut dyn Translator,
+    ty: &wasmparser::GlobalType,
+) -> Result<wasm_encoder::GlobalType> {
+    Ok(wasm_encoder::GlobalType {
+        val_type: t.translate_ty(&ty.content_type)?,
+        mutable: ty.mutable,
+    })
+}
+
+pub fn tag_type(t: &mut dyn Translator, ty: &wasmparser::TagType) -> Result<wasm_encoder::TagType> {
+    Ok(wasm_encoder::TagType {
+        kind: TagKind::Exception,
+        func_type_idx: t.remap(Item::Type, ty.func_type_idx)?,
+    })
+}
+
+pub fn ty(t: &mut dyn Translator, ty: &wasmparser::ValType) -> Result<ValType> {
+    match ty {
+        wasmparser::ValType::I32 => Ok(ValType::I32),
+        wasmparser::ValType::I64 => Ok(ValType::I64),
+        wasmparser::ValType::F32 => Ok(ValType::F32),
+        wasmparser::ValType::F64 => Ok(ValType::F64),
+        wasmparser::ValType::V128 => Ok(ValType::V128),
+        wasmparser::ValType::Ref(ty) => Ok(ValType::Ref(t.translate_refty(ty)?)),
+    }
+}
+
+pub fn refty(t: &mut dyn Translator, ty: &wasmparser::RefType) -> Result<RefType> {
+    Ok(RefType {
+        nullable: ty.nullable,
+        heap_type: t.translate_heapty(&ty.heap_type)?,
+    })
+}
+
+pub fn heapty(t: &mut dyn Translator, ty: &wasmparser::HeapType) -> Result<HeapType> {
+    match ty {
+        wasmparser::HeapType::Func => Ok(HeapType::Func),
+        wasmparser::HeapType::Extern => Ok(HeapType::Extern),
+        wasmparser::HeapType::TypedFunc(i) => {
+            Ok(HeapType::TypedFunc(t.remap(Item::Type, (*i).into())?))
+        }
+    }
+}
+
+pub fn global(t: &mut dyn Translator, global: Global, s: &mut GlobalSection) -> Result<()> {
+    let ty = t.translate_global_type(&global.ty)?;
+    let insn = t.translate_const_expr(
+        &global.init_expr,
+        &global.ty.content_type,
+        ConstExprKind::Global,
+    )?;
+    s.global(ty, &insn);
+    Ok(())
+}
+
+pub fn const_expr(
+    t: &mut dyn Translator,
+    e: &wasmparser::ConstExpr<'_>,
+    ctx: ConstExprKind,
+) -> Result<wasm_encoder::ConstExpr> {
+    let mut e = e.get_operators_reader();
+    let mut offset_bytes = Vec::new();
+    let op = e.read()?;
+    if let ConstExprKind::ElementFunction = ctx {
+        match op {
+            Operator::RefFunc { .. }
+            | Operator::RefNull {
+                hty: wasmparser::HeapType::Func,
+                ..
+            }
+            | Operator::GlobalGet { .. } => {}
+            _ => return Err(Error::msg("no mutations applicable")),
+        }
+    }
+    t.translate_op(&op)?.encode(&mut offset_bytes);
+    match e.read()? {
+        Operator::End if e.eof() => {}
+        _ => return Err(Error::msg("no mutations applicable")),
+    }
+    Ok(wasm_encoder::ConstExpr::raw(offset_bytes))
+}
+
+pub fn element(
+    t: &mut dyn Translator,
+    element: wasmparser::Element<'_>,
+    s: &mut ElementSection,
+) -> Result<()> {
+    let offset;
+    let mode = match &element.kind {
+        ElementKind::Active {
+            table_index,
+            offset_expr,
+        } => {
+            offset = t.translate_const_expr(
+                offset_expr,
+                &wasmparser::ValType::I32,
+                ConstExprKind::ElementOffset,
+            )?;
+            ElementMode::Active {
+                table: Some(t.remap(Item::Table, *table_index)?),
+                offset: &offset,
+            }
+        }
+        ElementKind::Passive => ElementMode::Passive,
+        ElementKind::Declared => ElementMode::Declared,
+    };
+    let element_type = t.translate_refty(&element.ty)?;
+    let functions;
+    let exprs;
+    let elements = match element.items {
+        wasmparser::ElementItems::Functions(reader) => {
+            functions = reader
+                .into_iter()
+                .map(|f| t.remap(Item::Function, f?))
+                .collect::<Result<Vec<_>, _>>()?;
+            Elements::Functions(&functions)
+        }
+        wasmparser::ElementItems::Expressions(reader) => {
+            exprs = reader
+                .into_iter()
+                .map(|f| {
+                    t.translate_const_expr(
+                        &f?,
+                        &wasmparser::ValType::Ref(element.ty),
+                        ConstExprKind::ElementFunction,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            Elements::Expressions(&exprs)
+        }
+    };
+    s.segment(ElementSegment {
+        mode,
+        element_type,
+        elements,
+    });
+    Ok(())
+}
+
+#[allow(unused_variables)]
+pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'static>> {
+    use wasm_encoder::Instruction as I;
+
+    macro_rules! translate {
+        ($( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
+            Ok(match op {
+                $(
+                    wasmparser::Operator::$op $({ $($arg),* })? => {
+                        $(
+                            $(let $arg = translate!(map $arg $arg);)*
+                        )?
+                        translate!(build $op $($($arg)*)?)
+                    }
+                )*
+            })
+        };
+
+        // This case is used to map, based on the name of the field, from the
+        // wasmparser payload type to the wasm-encoder payload type through
+        // `Translator` as applicable.
+        (map $arg:ident tag_index) => (t.remap(Item::Tag, *$arg)?);
+        (map $arg:ident function_index) => (t.remap(Item::Function, *$arg)?);
+        (map $arg:ident table) => (t.remap(Item::Table, *$arg)?);
+        (map $arg:ident table_index) => (t.remap(Item::Table, *$arg)?);
+        (map $arg:ident table) => (t.remap(Item::Table, *$arg)?);
+        (map $arg:ident dst_table) => (t.remap(Item::Table, *$arg)?);
+        (map $arg:ident src_table) => (t.remap(Item::Table, *$arg)?);
+        (map $arg:ident type_index) => (t.remap(Item::Type, *$arg)?);
+        (map $arg:ident global_index) => (t.remap(Item::Global, *$arg)?);
+        (map $arg:ident mem) => (t.remap(Item::Memory, *$arg)?);
+        (map $arg:ident src_mem) => (t.remap(Item::Memory, *$arg)?);
+        (map $arg:ident dst_mem) => (t.remap(Item::Memory, *$arg)?);
+        (map $arg:ident data_index) => (t.remap(Item::Data, *$arg)?);
+        (map $arg:ident elem_index) => (t.remap(Item::Element, *$arg)?);
+        (map $arg:ident blockty) => (t.translate_block_type($arg)?);
+        (map $arg:ident relative_depth) => (*$arg);
+        (map $arg:ident targets) => ((
+            $arg
+                .targets()
+                .collect::<Result<Vec<_>, wasmparser::BinaryReaderError>>()?
+                .into(),
+            $arg.default(),
+        ));
+        (map $arg:ident table_byte) => (());
+        (map $arg:ident mem_byte) => (());
+        (map $arg:ident flags) => (());
+        (map $arg:ident ty) => (t.translate_ty($arg)?);
+        (map $arg:ident hty) => (t.translate_heapty($arg)?);
+        (map $arg:ident memarg) => (t.translate_memarg($arg)?);
+        (map $arg:ident local_index) => (*$arg);
+        (map $arg:ident value) => ($arg);
+        (map $arg:ident lane) => (*$arg);
+        (map $arg:ident lanes) => (*$arg);
+
+        // This case takes the arguments of a wasmparser instruction and creates
+        // a wasm-encoder instruction. There are a few special cases for where
+        // the structure of a wasmparser instruction differs from that of
+        // wasm-encoder.
+        (build $op:ident) => (I::$op);
+        (build BrTable $arg:ident) => (I::BrTable($arg.0, $arg.1));
+        (build I32Const $arg:ident) => (I::I32Const(*$arg));
+        (build I64Const $arg:ident) => (I::I64Const(*$arg));
+        (build F32Const $arg:ident) => (I::F32Const(f32::from_bits($arg.bits())));
+        (build F64Const $arg:ident) => (I::F64Const(f64::from_bits($arg.bits())));
+        (build V128Const $arg:ident) => (I::V128Const($arg.i128()));
+        (build $op:ident $arg:ident) => (I::$op($arg));
+        (build CallIndirect $ty:ident $table:ident $_:ident) => (I::CallIndirect {
+            ty: $ty,
+            table: $table,
+        });
+        (build ReturnCallIndirect $ty:ident $table:ident) => (I::ReturnCallIndirect {
+            ty: $ty,
+            table: $table,
+        });
+        (build MemoryGrow $mem:ident $_:ident) => (I::MemoryGrow($mem));
+        (build MemorySize $mem:ident $_:ident) => (I::MemorySize($mem));
+        (build $op:ident $($arg:ident)*) => (I::$op { $($arg),* });
+    }
+
+    wasmparser::for_each_operator!(translate)
+}
+
+pub fn block_type(t: &mut dyn Translator, ty: &wasmparser::BlockType) -> Result<BlockType> {
+    match ty {
+        wasmparser::BlockType::Empty => Ok(BlockType::Empty),
+        wasmparser::BlockType::Type(ty) => Ok(BlockType::Result(t.translate_ty(ty)?)),
+        wasmparser::BlockType::FuncType(f) => Ok(BlockType::FunctionType(t.remap(Item::Type, *f)?)),
+    }
+}
+
+pub fn memarg(t: &mut dyn Translator, memarg: &wasmparser::MemArg) -> Result<MemArg> {
+    Ok(MemArg {
+        offset: memarg.offset,
+        align: memarg.align.into(),
+        memory_index: t.remap(Item::Memory, memarg.memory)?,
+    })
+}
+
+pub fn data(t: &mut dyn Translator, data: wasmparser::Data<'_>, s: &mut DataSection) -> Result<()> {
+    let offset;
+    let mode = match &data.kind {
+        DataKind::Active {
+            memory_index,
+            offset_expr,
+        } => {
+            offset = t.translate_const_expr(
+                offset_expr,
+                &wasmparser::ValType::I32,
+                ConstExprKind::DataOffset,
+            )?;
+            DataSegmentMode::Active {
+                memory_index: t.remap(Item::Memory, *memory_index)?,
+                offset: &offset,
+            }
+        }
+        DataKind::Passive => DataSegmentMode::Passive,
+    };
+    s.segment(DataSegment {
+        mode,
+        data: data.data.iter().copied(),
+    });
+    Ok(())
+}
+
+pub fn code(t: &mut dyn Translator, body: FunctionBody<'_>, s: &mut CodeSection) -> Result<()> {
+    let locals = body
+        .get_locals_reader()?
+        .into_iter()
+        .map(|local| {
+            let (cnt, ty) = local?;
+            Ok((cnt, t.translate_ty(&ty)?))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut func = Function::new(locals);
+
+    let mut reader = body.get_operators_reader()?;
+    reader.allow_memarg64(true);
+    for op in reader {
+        let op = op?;
+        func.instruction(&t.translate_op(&op)?);
+    }
+    s.function(&func);
+    Ok(())
+}

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -656,12 +656,6 @@ impl<'a> Translator {
                     memory_index: *memory_index,
                     offset_instr,
                 }
-                // let offset = self.const_expr(offset_expr, ConstExprKind::DataOffset)?;
-                // let offset_box = Box::new(offset);
-                // DataSegmentMode::Active {
-                //     memory_index: *memory_index,
-                //     offset: Box::leak(offset_box), // todo satisfy static lifetime for the `mode` binding
-                // }
             }
             DataKind::Passive => DataMode::Passive,
         };

--- a/bin/evm2near/src/wasm_translate.rs
+++ b/bin/evm2near/src/wasm_translate.rs
@@ -10,7 +10,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
         .map(|p| p.unwrap())
         .collect::<Vec<_>>();
 
-    let mut t = DefaultTranslator;
+    let mut t = Translator;
 
     let mut code_section_size: Option<u32> = None;
     let mut code_section = wasm_encoder::CodeSection::new();
@@ -28,7 +28,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
             wasmparser::Payload::TypeSection(type_section) => {
                 let mut type_sect = wasm_encoder::TypeSection::new();
                 for typ in type_section {
-                    t.translate_type_def(typ?, &mut type_sect)?;
+                    t.type_def(typ?, &mut type_sect)?;
                 }
                 m.section(&type_sect);
             }
@@ -36,7 +36,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
                 let mut import_sect = wasm_encoder::ImportSection::new();
                 for import in import_section {
                     let import = import?;
-                    let typ = t.translate_type_ref(import.ty)?;
+                    let typ = t.type_ref(import.ty)?;
                     import_sect.import(import.module, import.name, typ);
                 }
                 m.section(&import_sect);
@@ -52,7 +52,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
                 let mut table_sect = wasm_encoder::TableSection::new();
                 for table in table_section {
                     let table = table?;
-                    let table_type = table_type(&mut t, &table.ty)?; // todo TableInit is not used!
+                    let table_type = t.table_type(&table.ty)?; // todo TableInit is not used!
                     table_sect.table(table_type);
                 }
                 m.section(&table_sect);
@@ -61,7 +61,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
                 let mut memory_sect = wasm_encoder::MemorySection::new();
                 for mem in memory_section {
                     let mem = mem?;
-                    let memory_type = t.translate_memory_type(&mem)?;
+                    let memory_type = t.memory_type(&mem)?;
                     memory_sect.memory(memory_type);
                 }
                 m.section(&memory_sect);
@@ -70,7 +70,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
                 let mut tag_sect = wasm_encoder::TagSection::new();
                 for tag in tag_section {
                     let tag = tag?;
-                    let tag_type = t.translate_tag_type(&tag)?;
+                    let tag_type = t.tag_type(&tag)?;
                     tag_sect.tag(tag_type);
                 }
                 m.section(&tag_sect);
@@ -78,7 +78,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
             wasmparser::Payload::GlobalSection(global_section) => {
                 let mut glob_sect = wasm_encoder::GlobalSection::new();
                 for glob in global_section {
-                    t.translate_global(glob?, &mut glob_sect)?;
+                    t.global(glob?, &mut glob_sect)?;
                 }
                 m.section(&glob_sect);
             }
@@ -86,7 +86,7 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
                 let mut export_sect = wasm_encoder::ExportSection::new();
                 for export in export_section {
                     let export = export?;
-                    export_sect.export(export.name, ext_kind(export.kind), export.index);
+                    export_sect.export(export.name, t.ext_kind(export.kind), export.index);
                 }
                 m.section(&export_sect);
             }
@@ -100,67 +100,65 @@ pub fn parse(wasm: Vec<u8>) -> Result<wasm_encoder::Module> {
             wasmparser::Payload::ElementSection(element_section) => {
                 let mut element_sect = wasm_encoder::ElementSection::new();
                 for element in element_section {
-                    t.translate_element(element?, &mut element_sect)?;
+                    t.element(element?, &mut element_sect)?;
                 }
                 m.section(&element_sect);
             }
-            wasmparser::Payload::DataCountSection { count, range } => {
+            wasmparser::Payload::DataCountSection { count, range: _ } => {
                 let data_count_sect = wasm_encoder::DataCountSection { count };
                 m.section(&data_count_sect);
             }
             wasmparser::Payload::DataSection(data_section) => {
                 let mut data_sect = wasm_encoder::DataSection::new();
                 for data in data_section {
-                    t.translate_data(data?, &mut data_sect)?;
+                    t.data(data?, &mut data_sect)?;
                 }
                 m.section(&data_sect);
             }
-            wasmparser::Payload::CodeSectionStart { count, range, size } => {
+            wasmparser::Payload::CodeSectionStart {
+                count,
+                range: _,
+                size: _,
+            } => {
                 code_section_size = Some(count);
             }
             wasmparser::Payload::CodeSectionEntry(code_section_entry) => {
                 assert!(code_section_size.is_some());
-                t.translate_code(code_section_entry, &mut code_section)?;
+                t.code(code_section_entry, &mut code_section)?;
                 let desired_size = code_section_size.unwrap();
                 if code_section.len() == desired_size {
                     m.section(&code_section);
                     code_section_size = None;
                 }
             }
-            wasmparser::Payload::ModuleSection { parser, range } => todo!(),
+            wasmparser::Payload::ModuleSection {
+                parser: _,
+                range: _,
+            } => todo!(),
             wasmparser::Payload::InstanceSection(_) => todo!(),
             wasmparser::Payload::CoreTypeSection(_) => todo!(),
-            wasmparser::Payload::ComponentSection { parser, range } => todo!(),
+            wasmparser::Payload::ComponentSection {
+                parser: _,
+                range: _,
+            } => todo!(),
             wasmparser::Payload::ComponentInstanceSection(_) => todo!(),
             wasmparser::Payload::ComponentAliasSection(_) => todo!(),
             wasmparser::Payload::ComponentTypeSection(_) => todo!(),
             wasmparser::Payload::ComponentCanonicalSection(_) => todo!(),
-            wasmparser::Payload::ComponentStartSection { start, range } => todo!(),
+            wasmparser::Payload::ComponentStartSection { start: _, range: _ } => todo!(),
             wasmparser::Payload::ComponentImportSection(_) => todo!(),
             wasmparser::Payload::ComponentExportSection(_) => todo!(),
             wasmparser::Payload::CustomSection(_) => todo!(),
             wasmparser::Payload::UnknownSection {
-                id,
-                contents,
-                range,
+                id: _,
+                contents: _,
+                range: _,
             } => todo!(),
-            wasmparser::Payload::End(end) => {}
+            wasmparser::Payload::End(_end) => {}
         }
     }
 
     Ok(m)
-}
-
-#[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
-pub enum Item {
-    Function,
-    Table,
-    Memory,
-    Tag,
-    Global,
-    Type,
-    Data,
-    Element,
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]
@@ -172,17 +170,14 @@ pub enum ConstExprKind {
     TableInit,
 }
 
-pub trait Translator {
-    fn as_obj(&mut self) -> &mut dyn Translator;
+pub struct Translator;
 
-    fn translate_type_ref(
-        &mut self,
-        type_ref: wasmparser::TypeRef,
-    ) -> Result<wasm_encoder::EntityType> {
+impl Translator {
+    fn type_ref(&mut self, type_ref: wasmparser::TypeRef) -> Result<wasm_encoder::EntityType> {
         match type_ref {
             wasmparser::TypeRef::Func(f) => Ok(EntityType::Function(f)),
             wasmparser::TypeRef::Table(t) => {
-                let element_type = self.translate_refty(&t.element_type)?;
+                let element_type = self.refty(&t.element_type)?;
                 Ok(EntityType::Table(TableType {
                     element_type,
                     minimum: t.initial,
@@ -196,442 +191,315 @@ pub trait Translator {
                 shared: m.shared,
             })),
             wasmparser::TypeRef::Global(g) => Ok(EntityType::Global(GlobalType {
-                val_type: self.translate_ty(&g.content_type)?,
+                val_type: self.ty(&g.content_type)?,
                 mutable: g.mutable,
             })),
-            wasmparser::TypeRef::Tag(t) => Ok(EntityType::Tag(self.translate_tag_type(&t)?)),
+            wasmparser::TypeRef::Tag(t) => Ok(EntityType::Tag(self.tag_type(&t)?)),
         }
     }
 
-    fn translate_type_def(&mut self, ty: Type, s: &mut TypeSection) -> Result<()> {
-        type_def(self.as_obj(), ty, s)
+    pub fn type_def(&mut self, ty: Type, s: &mut TypeSection) -> Result<()> {
+        match ty {
+            Type::Func(f) => {
+                s.function(
+                    f.params()
+                        .iter()
+                        .map(|ty| self.ty(ty))
+                        .collect::<Result<Vec<_>>>()?,
+                    f.results()
+                        .iter()
+                        .map(|ty| self.ty(ty))
+                        .collect::<Result<Vec<_>>>()?,
+                );
+                Ok(())
+            }
+        }
     }
 
-    fn translate_table_type(
-        &mut self,
-        ty: &wasmparser::TableType,
-    ) -> Result<wasm_encoder::TableType> {
-        table_type(self.as_obj(), ty)
+    pub fn ext_kind(&mut self, ekind: wasmparser::ExternalKind) -> ExportKind {
+        match ekind {
+            wasmparser::ExternalKind::Func => ExportKind::Func,
+            wasmparser::ExternalKind::Table => ExportKind::Table,
+            wasmparser::ExternalKind::Memory => ExportKind::Memory,
+            wasmparser::ExternalKind::Global => ExportKind::Global,
+            wasmparser::ExternalKind::Tag => ExportKind::Tag,
+        }
     }
 
-    fn translate_memory_type(
-        &mut self,
-        ty: &wasmparser::MemoryType,
-    ) -> Result<wasm_encoder::MemoryType> {
-        memory_type(self.as_obj(), ty)
+    pub fn table_type(&mut self, ty: &wasmparser::TableType) -> Result<wasm_encoder::TableType> {
+        Ok(wasm_encoder::TableType {
+            element_type: self.refty(&ty.element_type)?,
+            minimum: ty.initial,
+            maximum: ty.maximum,
+        })
     }
 
-    fn translate_global_type(
-        &mut self,
-        ty: &wasmparser::GlobalType,
-    ) -> Result<wasm_encoder::GlobalType> {
-        global_type(self.as_obj(), ty)
+    pub fn memory_type(&mut self, ty: &wasmparser::MemoryType) -> Result<wasm_encoder::MemoryType> {
+        Ok(wasm_encoder::MemoryType {
+            memory64: ty.memory64,
+            minimum: ty.initial,
+            maximum: ty.maximum,
+            shared: ty.shared,
+        })
     }
 
-    fn translate_tag_type(&mut self, ty: &wasmparser::TagType) -> Result<wasm_encoder::TagType> {
-        tag_type(self.as_obj(), ty)
+    pub fn global_type(&mut self, ty: &wasmparser::GlobalType) -> Result<wasm_encoder::GlobalType> {
+        Ok(wasm_encoder::GlobalType {
+            val_type: self.ty(&ty.content_type)?,
+            mutable: ty.mutable,
+        })
     }
 
-    fn translate_ty(&mut self, t: &wasmparser::ValType) -> Result<ValType> {
-        ty(self.as_obj(), t)
+    pub fn tag_type(&mut self, ty: &wasmparser::TagType) -> Result<wasm_encoder::TagType> {
+        Ok(wasm_encoder::TagType {
+            kind: TagKind::Exception,
+            func_type_idx: ty.func_type_idx,
+        })
     }
 
-    fn translate_refty(&mut self, t: &wasmparser::RefType) -> Result<RefType> {
-        refty(self.as_obj(), t)
+    pub fn ty(&mut self, ty: &wasmparser::ValType) -> Result<ValType> {
+        match ty {
+            wasmparser::ValType::I32 => Ok(ValType::I32),
+            wasmparser::ValType::I64 => Ok(ValType::I64),
+            wasmparser::ValType::F32 => Ok(ValType::F32),
+            wasmparser::ValType::F64 => Ok(ValType::F64),
+            wasmparser::ValType::V128 => Ok(ValType::V128),
+            wasmparser::ValType::Ref(ty) => Ok(ValType::Ref(self.refty(ty)?)),
+        }
     }
 
-    fn translate_heapty(&mut self, t: &wasmparser::HeapType) -> Result<HeapType> {
-        heapty(self.as_obj(), t)
+    pub fn refty(&mut self, ty: &wasmparser::RefType) -> Result<RefType> {
+        Ok(RefType {
+            nullable: ty.nullable,
+            heap_type: self.heapty(&ty.heap_type)?,
+        })
     }
 
-    fn translate_global(&mut self, g: Global, s: &mut GlobalSection) -> Result<()> {
-        global(self.as_obj(), g, s)
+    pub fn heapty(&mut self, ty: &wasmparser::HeapType) -> Result<HeapType> {
+        match ty {
+            wasmparser::HeapType::Func => Ok(HeapType::Func),
+            wasmparser::HeapType::Extern => Ok(HeapType::Extern),
+            wasmparser::HeapType::TypedFunc(i) => Ok(HeapType::TypedFunc((*i).into())),
+        }
     }
 
-    fn translate_const_expr(
+    pub fn global(&mut self, global: Global, s: &mut GlobalSection) -> Result<()> {
+        let ty = self.global_type(&global.ty)?;
+        let insn = self.const_expr(&global.init_expr, ConstExprKind::Global)?;
+        s.global(ty, &insn);
+        Ok(())
+    }
+
+    pub fn const_expr(
         &mut self,
         e: &wasmparser::ConstExpr<'_>,
-        _ty: &wasmparser::ValType,
         ctx: ConstExprKind,
     ) -> Result<wasm_encoder::ConstExpr> {
-        const_expr(self.as_obj(), e, ctx)
-    }
-
-    fn translate_element(
-        &mut self,
-        e: wasmparser::Element<'_>,
-        s: &mut ElementSection,
-    ) -> Result<()> {
-        element(self.as_obj(), e, s)
-    }
-
-    fn translate_data(&mut self, d: wasmparser::Data<'_>, s: &mut DataSection) -> Result<()> {
-        data(self.as_obj(), d, s)
-    }
-
-    fn translate_code(&mut self, body: FunctionBody<'_>, s: &mut CodeSection) -> Result<()> {
-        code(self.as_obj(), body, s)
-    }
-
-    fn translate_op(&mut self, e: &Operator<'_>) -> Result<Instruction<'static>> {
-        op(self.as_obj(), e)
-    }
-
-    fn translate_block_type(&mut self, ty: &wasmparser::BlockType) -> Result<BlockType> {
-        block_type(self.as_obj(), ty)
-    }
-
-    fn translate_memarg(&mut self, arg: &wasmparser::MemArg) -> Result<MemArg> {
-        memarg(self.as_obj(), arg)
-    }
-
-    fn remap(&mut self, item: Item, idx: u32) -> Result<u32> {
-        // drop(item);
-        Ok(idx)
-    }
-}
-
-pub struct DefaultTranslator;
-
-impl Translator for DefaultTranslator {
-    fn as_obj(&mut self) -> &mut dyn Translator {
-        self
-    }
-}
-
-pub fn type_def(t: &mut dyn Translator, ty: Type, s: &mut TypeSection) -> Result<()> {
-    match ty {
-        Type::Func(f) => {
-            s.function(
-                f.params()
-                    .iter()
-                    .map(|ty| t.translate_ty(ty))
-                    .collect::<Result<Vec<_>>>()?,
-                f.results()
-                    .iter()
-                    .map(|ty| t.translate_ty(ty))
-                    .collect::<Result<Vec<_>>>()?,
-            );
-            Ok(())
-        }
-    }
-}
-
-pub fn ext_kind(ekind: wasmparser::ExternalKind) -> ExportKind {
-    match ekind {
-        wasmparser::ExternalKind::Func => ExportKind::Func,
-        wasmparser::ExternalKind::Table => ExportKind::Table,
-        wasmparser::ExternalKind::Memory => ExportKind::Memory,
-        wasmparser::ExternalKind::Global => ExportKind::Global,
-        wasmparser::ExternalKind::Tag => ExportKind::Tag,
-    }
-}
-
-pub fn table_type(
-    t: &mut dyn Translator,
-    ty: &wasmparser::TableType,
-) -> Result<wasm_encoder::TableType> {
-    Ok(wasm_encoder::TableType {
-        element_type: t.translate_refty(&ty.element_type)?,
-        minimum: ty.initial,
-        maximum: ty.maximum,
-    })
-}
-
-pub fn memory_type(
-    _t: &mut dyn Translator,
-    ty: &wasmparser::MemoryType,
-) -> Result<wasm_encoder::MemoryType> {
-    Ok(wasm_encoder::MemoryType {
-        memory64: ty.memory64,
-        minimum: ty.initial,
-        maximum: ty.maximum,
-        shared: ty.shared,
-    })
-}
-
-pub fn global_type(
-    t: &mut dyn Translator,
-    ty: &wasmparser::GlobalType,
-) -> Result<wasm_encoder::GlobalType> {
-    Ok(wasm_encoder::GlobalType {
-        val_type: t.translate_ty(&ty.content_type)?,
-        mutable: ty.mutable,
-    })
-}
-
-pub fn tag_type(t: &mut dyn Translator, ty: &wasmparser::TagType) -> Result<wasm_encoder::TagType> {
-    Ok(wasm_encoder::TagType {
-        kind: TagKind::Exception,
-        func_type_idx: t.remap(Item::Type, ty.func_type_idx)?,
-    })
-}
-
-pub fn ty(t: &mut dyn Translator, ty: &wasmparser::ValType) -> Result<ValType> {
-    match ty {
-        wasmparser::ValType::I32 => Ok(ValType::I32),
-        wasmparser::ValType::I64 => Ok(ValType::I64),
-        wasmparser::ValType::F32 => Ok(ValType::F32),
-        wasmparser::ValType::F64 => Ok(ValType::F64),
-        wasmparser::ValType::V128 => Ok(ValType::V128),
-        wasmparser::ValType::Ref(ty) => Ok(ValType::Ref(t.translate_refty(ty)?)),
-    }
-}
-
-pub fn refty(t: &mut dyn Translator, ty: &wasmparser::RefType) -> Result<RefType> {
-    Ok(RefType {
-        nullable: ty.nullable,
-        heap_type: t.translate_heapty(&ty.heap_type)?,
-    })
-}
-
-pub fn heapty(t: &mut dyn Translator, ty: &wasmparser::HeapType) -> Result<HeapType> {
-    match ty {
-        wasmparser::HeapType::Func => Ok(HeapType::Func),
-        wasmparser::HeapType::Extern => Ok(HeapType::Extern),
-        wasmparser::HeapType::TypedFunc(i) => {
-            Ok(HeapType::TypedFunc(t.remap(Item::Type, (*i).into())?))
-        }
-    }
-}
-
-pub fn global(t: &mut dyn Translator, global: Global, s: &mut GlobalSection) -> Result<()> {
-    let ty = t.translate_global_type(&global.ty)?;
-    let insn = t.translate_const_expr(
-        &global.init_expr,
-        &global.ty.content_type,
-        ConstExprKind::Global,
-    )?;
-    s.global(ty, &insn);
-    Ok(())
-}
-
-pub fn const_expr(
-    t: &mut dyn Translator,
-    e: &wasmparser::ConstExpr<'_>,
-    ctx: ConstExprKind,
-) -> Result<wasm_encoder::ConstExpr> {
-    let mut e = e.get_operators_reader();
-    let mut offset_bytes = Vec::new();
-    let op = e.read()?;
-    if let ConstExprKind::ElementFunction = ctx {
-        match op {
-            Operator::RefFunc { .. }
-            | Operator::RefNull {
-                hty: wasmparser::HeapType::Func,
-                ..
+        let mut e = e.get_operators_reader();
+        let mut offset_bytes = Vec::new();
+        let op = e.read()?;
+        if let ConstExprKind::ElementFunction = ctx {
+            match op {
+                Operator::RefFunc { .. }
+                | Operator::RefNull {
+                    hty: wasmparser::HeapType::Func,
+                    ..
+                }
+                | Operator::GlobalGet { .. } => {}
+                _ => return Err(Error::msg("no mutations applicable")),
             }
-            | Operator::GlobalGet { .. } => {}
+        }
+        self.op(&op)?.encode(&mut offset_bytes);
+        match e.read()? {
+            Operator::End if e.eof() => {}
             _ => return Err(Error::msg("no mutations applicable")),
         }
+        Ok(wasm_encoder::ConstExpr::raw(offset_bytes))
     }
-    t.translate_op(&op)?.encode(&mut offset_bytes);
-    match e.read()? {
-        Operator::End if e.eof() => {}
-        _ => return Err(Error::msg("no mutations applicable")),
-    }
-    Ok(wasm_encoder::ConstExpr::raw(offset_bytes))
-}
 
-pub fn element(
-    t: &mut dyn Translator,
-    element: wasmparser::Element<'_>,
-    s: &mut ElementSection,
-) -> Result<()> {
-    let offset;
-    let mode = match &element.kind {
-        ElementKind::Active {
-            table_index,
-            offset_expr,
-        } => {
-            offset = t.translate_const_expr(
+    pub fn element(
+        &mut self,
+        element: wasmparser::Element<'_>,
+        s: &mut ElementSection,
+    ) -> Result<()> {
+        let offset;
+        let mode = match &element.kind {
+            ElementKind::Active {
+                table_index,
                 offset_expr,
-                &wasmparser::ValType::I32,
-                ConstExprKind::ElementOffset,
-            )?;
-            ElementMode::Active {
-                table: Some(t.remap(Item::Table, *table_index)?),
-                offset: &offset,
+            } => {
+                offset = self.const_expr(offset_expr, ConstExprKind::ElementOffset)?;
+                ElementMode::Active {
+                    table: Some(*table_index),
+                    offset: &offset,
+                }
             }
-        }
-        ElementKind::Passive => ElementMode::Passive,
-        ElementKind::Declared => ElementMode::Declared,
-    };
-    let element_type = t.translate_refty(&element.ty)?;
-    let functions;
-    let exprs;
-    let elements = match element.items {
-        wasmparser::ElementItems::Functions(reader) => {
-            functions = reader
-                .into_iter()
-                .map(|f| t.remap(Item::Function, f?))
-                .collect::<Result<Vec<_>, _>>()?;
-            Elements::Functions(&functions)
-        }
-        wasmparser::ElementItems::Expressions(reader) => {
-            exprs = reader
-                .into_iter()
-                .map(|f| {
-                    t.translate_const_expr(
-                        &f?,
-                        &wasmparser::ValType::Ref(element.ty),
-                        ConstExprKind::ElementFunction,
-                    )
-                })
-                .collect::<Result<Vec<_>, _>>()?;
-            Elements::Expressions(&exprs)
-        }
-    };
-    s.segment(ElementSegment {
-        mode,
-        element_type,
-        elements,
-    });
-    Ok(())
-}
-
-#[allow(unused_variables)]
-pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'static>> {
-    use wasm_encoder::Instruction as I;
-
-    macro_rules! translate {
-        ($( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
-            Ok(match op {
-                $(
-                    wasmparser::Operator::$op $({ $($arg),* })? => {
-                        $(
-                            $(let $arg = translate!(map $arg $arg);)*
-                        )?
-                        translate!(build $op $($($arg)*)?)
-                    }
-                )*
-            })
+            ElementKind::Passive => ElementMode::Passive,
+            ElementKind::Declared => ElementMode::Declared,
         };
-
-        // This case is used to map, based on the name of the field, from the
-        // wasmparser payload type to the wasm-encoder payload type through
-        // `Translator` as applicable.
-        (map $arg:ident tag_index) => (t.remap(Item::Tag, *$arg)?);
-        (map $arg:ident function_index) => (t.remap(Item::Function, *$arg)?);
-        (map $arg:ident table) => (t.remap(Item::Table, *$arg)?);
-        (map $arg:ident table_index) => (t.remap(Item::Table, *$arg)?);
-        (map $arg:ident table) => (t.remap(Item::Table, *$arg)?);
-        (map $arg:ident dst_table) => (t.remap(Item::Table, *$arg)?);
-        (map $arg:ident src_table) => (t.remap(Item::Table, *$arg)?);
-        (map $arg:ident type_index) => (t.remap(Item::Type, *$arg)?);
-        (map $arg:ident global_index) => (t.remap(Item::Global, *$arg)?);
-        (map $arg:ident mem) => (t.remap(Item::Memory, *$arg)?);
-        (map $arg:ident src_mem) => (t.remap(Item::Memory, *$arg)?);
-        (map $arg:ident dst_mem) => (t.remap(Item::Memory, *$arg)?);
-        (map $arg:ident data_index) => (t.remap(Item::Data, *$arg)?);
-        (map $arg:ident elem_index) => (t.remap(Item::Element, *$arg)?);
-        (map $arg:ident blockty) => (t.translate_block_type($arg)?);
-        (map $arg:ident relative_depth) => (*$arg);
-        (map $arg:ident targets) => ((
-            $arg
-                .targets()
-                .collect::<Result<Vec<_>, wasmparser::BinaryReaderError>>()?
-                .into(),
-            $arg.default(),
-        ));
-        (map $arg:ident table_byte) => (());
-        (map $arg:ident mem_byte) => (());
-        (map $arg:ident flags) => (());
-        (map $arg:ident ty) => (t.translate_ty($arg)?);
-        (map $arg:ident hty) => (t.translate_heapty($arg)?);
-        (map $arg:ident memarg) => (t.translate_memarg($arg)?);
-        (map $arg:ident local_index) => (*$arg);
-        (map $arg:ident value) => ($arg);
-        (map $arg:ident lane) => (*$arg);
-        (map $arg:ident lanes) => (*$arg);
-
-        // This case takes the arguments of a wasmparser instruction and creates
-        // a wasm-encoder instruction. There are a few special cases for where
-        // the structure of a wasmparser instruction differs from that of
-        // wasm-encoder.
-        (build $op:ident) => (I::$op);
-        (build BrTable $arg:ident) => (I::BrTable($arg.0, $arg.1));
-        (build I32Const $arg:ident) => (I::I32Const(*$arg));
-        (build I64Const $arg:ident) => (I::I64Const(*$arg));
-        (build F32Const $arg:ident) => (I::F32Const(f32::from_bits($arg.bits())));
-        (build F64Const $arg:ident) => (I::F64Const(f64::from_bits($arg.bits())));
-        (build V128Const $arg:ident) => (I::V128Const($arg.i128()));
-        (build $op:ident $arg:ident) => (I::$op($arg));
-        (build CallIndirect $ty:ident $table:ident $_:ident) => (I::CallIndirect {
-            ty: $ty,
-            table: $table,
-        });
-        (build ReturnCallIndirect $ty:ident $table:ident) => (I::ReturnCallIndirect {
-            ty: $ty,
-            table: $table,
-        });
-        (build MemoryGrow $mem:ident $_:ident) => (I::MemoryGrow($mem));
-        (build MemorySize $mem:ident $_:ident) => (I::MemorySize($mem));
-        (build $op:ident $($arg:ident)*) => (I::$op { $($arg),* });
-    }
-
-    wasmparser::for_each_operator!(translate)
-}
-
-pub fn block_type(t: &mut dyn Translator, ty: &wasmparser::BlockType) -> Result<BlockType> {
-    match ty {
-        wasmparser::BlockType::Empty => Ok(BlockType::Empty),
-        wasmparser::BlockType::Type(ty) => Ok(BlockType::Result(t.translate_ty(ty)?)),
-        wasmparser::BlockType::FuncType(f) => Ok(BlockType::FunctionType(t.remap(Item::Type, *f)?)),
-    }
-}
-
-pub fn memarg(t: &mut dyn Translator, memarg: &wasmparser::MemArg) -> Result<MemArg> {
-    Ok(MemArg {
-        offset: memarg.offset,
-        align: memarg.align.into(),
-        memory_index: t.remap(Item::Memory, memarg.memory)?,
-    })
-}
-
-pub fn data(t: &mut dyn Translator, data: wasmparser::Data<'_>, s: &mut DataSection) -> Result<()> {
-    let offset;
-    let mode = match &data.kind {
-        DataKind::Active {
-            memory_index,
-            offset_expr,
-        } => {
-            offset = t.translate_const_expr(
-                offset_expr,
-                &wasmparser::ValType::I32,
-                ConstExprKind::DataOffset,
-            )?;
-            DataSegmentMode::Active {
-                memory_index: t.remap(Item::Memory, *memory_index)?,
-                offset: &offset,
+        let element_type = self.refty(&element.ty)?;
+        let functions;
+        let exprs;
+        let elements = match element.items {
+            wasmparser::ElementItems::Functions(reader) => {
+                functions = reader.into_iter().collect::<Result<Vec<_>, _>>()?;
+                Elements::Functions(&functions)
             }
-        }
-        DataKind::Passive => DataSegmentMode::Passive,
-    };
-    s.segment(DataSegment {
-        mode,
-        data: data.data.iter().copied(),
-    });
-    Ok(())
-}
-
-pub fn code(t: &mut dyn Translator, body: FunctionBody<'_>, s: &mut CodeSection) -> Result<()> {
-    let locals = body
-        .get_locals_reader()?
-        .into_iter()
-        .map(|local| {
-            let (cnt, ty) = local?;
-            Ok((cnt, t.translate_ty(&ty)?))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let mut func = Function::new(locals);
-
-    let mut reader = body.get_operators_reader()?;
-    reader.allow_memarg64(true);
-    for op in reader {
-        let op = op?;
-        func.instruction(&t.translate_op(&op)?);
+            wasmparser::ElementItems::Expressions(reader) => {
+                exprs = reader
+                    .into_iter()
+                    .map(|f| self.const_expr(&f?, ConstExprKind::ElementFunction))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Elements::Expressions(&exprs)
+            }
+        };
+        s.segment(ElementSegment {
+            mode,
+            element_type,
+            elements,
+        });
+        Ok(())
     }
-    s.function(&func);
-    Ok(())
+
+    #[allow(unused_variables)]
+    pub fn op(&mut self, op: &Operator<'_>) -> Result<Instruction<'static>> {
+        use wasm_encoder::Instruction as I;
+
+        macro_rules! translate {
+            ($( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
+                Ok(match op {
+                    $(
+                        wasmparser::Operator::$op $({ $($arg),* })? => {
+                            $(
+                                $(let $arg = translate!(map $arg $arg);)*
+                            )?
+                            translate!(build $op $($($arg)*)?)
+                        }
+                    )*
+                })
+            };
+
+            // This case is used to map, based on the name of the field, from the
+            // wasmparser payload type to the wasm-encoder payload type through
+            // `Translator` as applicable.
+            (map $arg:ident tag_index) => (*$arg);
+            (map $arg:ident function_index) => (*$arg);
+            (map $arg:ident table) => (*$arg);
+            (map $arg:ident table_index) => (*$arg);
+            (map $arg:ident table) => (*$arg);
+            (map $arg:ident dst_table) => (*$arg);
+            (map $arg:ident src_table) => (*$arg);
+            (map $arg:ident type_index) => (*$arg);
+            (map $arg:ident global_index) => (*$arg);
+            (map $arg:ident mem) => (*$arg);
+            (map $arg:ident src_mem) => (*$arg);
+            (map $arg:ident dst_mem) => (*$arg);
+            (map $arg:ident data_index) => (*$arg);
+            (map $arg:ident elem_index) => (*$arg);
+            (map $arg:ident blockty) => (self.block_type($arg)?);
+            (map $arg:ident relative_depth) => (*$arg);
+            (map $arg:ident targets) => ((
+                $arg
+                    .targets()
+                    .collect::<Result<Vec<_>, wasmparser::BinaryReaderError>>()?
+                    .into(),
+                $arg.default(),
+            ));
+            (map $arg:ident table_byte) => (());
+            (map $arg:ident mem_byte) => (());
+            (map $arg:ident flags) => (());
+            (map $arg:ident ty) => (self.ty($arg)?);
+            (map $arg:ident hty) => (self.heapty($arg)?);
+            (map $arg:ident memarg) => (self.memarg($arg)?);
+            (map $arg:ident local_index) => (*$arg);
+            (map $arg:ident value) => ($arg);
+            (map $arg:ident lane) => (*$arg);
+            (map $arg:ident lanes) => (*$arg);
+
+            // This case takes the arguments of a wasmparser instruction and creates
+            // a wasm-encoder instruction. There are a few special cases for where
+            // the structure of a wasmparser instruction differs from that of
+            // wasm-encoder.
+            (build $op:ident) => (I::$op);
+            (build BrTable $arg:ident) => (I::BrTable($arg.0, $arg.1));
+            (build I32Const $arg:ident) => (I::I32Const(*$arg));
+            (build I64Const $arg:ident) => (I::I64Const(*$arg));
+            (build F32Const $arg:ident) => (I::F32Const(f32::from_bits($arg.bits())));
+            (build F64Const $arg:ident) => (I::F64Const(f64::from_bits($arg.bits())));
+            (build V128Const $arg:ident) => (I::V128Const($arg.i128()));
+            (build $op:ident $arg:ident) => (I::$op($arg));
+            (build CallIndirect $ty:ident $table:ident $_:ident) => (I::CallIndirect {
+                ty: $ty,
+                table: $table,
+            });
+            (build ReturnCallIndirect $ty:ident $table:ident) => (I::ReturnCallIndirect {
+                ty: $ty,
+                table: $table,
+            });
+            (build MemoryGrow $mem:ident $_:ident) => (I::MemoryGrow($mem));
+            (build MemorySize $mem:ident $_:ident) => (I::MemorySize($mem));
+            (build $op:ident $($arg:ident)*) => (I::$op { $($arg),* });
+        }
+
+        wasmparser::for_each_operator!(translate)
+    }
+
+    pub fn block_type(&mut self, ty: &wasmparser::BlockType) -> Result<BlockType> {
+        match ty {
+            wasmparser::BlockType::Empty => Ok(BlockType::Empty),
+            wasmparser::BlockType::Type(ty) => Ok(BlockType::Result(self.ty(ty)?)),
+            wasmparser::BlockType::FuncType(f) => Ok(BlockType::FunctionType(*f)),
+        }
+    }
+
+    pub fn memarg(&mut self, memarg: &wasmparser::MemArg) -> Result<MemArg> {
+        Ok(MemArg {
+            offset: memarg.offset,
+            align: memarg.align.into(),
+            memory_index: memarg.memory,
+        })
+    }
+
+    pub fn data(&mut self, data: wasmparser::Data<'_>, s: &mut DataSection) -> Result<()> {
+        let offset;
+        let mode = match &data.kind {
+            DataKind::Active {
+                memory_index,
+                offset_expr,
+            } => {
+                offset = self.const_expr(offset_expr, ConstExprKind::DataOffset)?;
+                DataSegmentMode::Active {
+                    memory_index: *memory_index,
+                    offset: &offset,
+                }
+            }
+            DataKind::Passive => DataSegmentMode::Passive,
+        };
+        s.segment(DataSegment {
+            mode,
+            data: data.data.iter().copied(),
+        });
+        Ok(())
+    }
+
+    pub fn code(&mut self, body: FunctionBody<'_>, s: &mut CodeSection) -> Result<()> {
+        let locals = body
+            .get_locals_reader()?
+            .into_iter()
+            .map(|local| {
+                let (cnt, ty) = local?;
+                Ok((cnt, self.ty(&ty)?))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut func = Function::new(locals);
+
+        let mut reader = body.get_operators_reader()?;
+        reader.allow_memarg64(true);
+        for op in reader {
+            let op = op?;
+            func.instruction(&self.op(&op)?);
+        }
+        s.function(&func);
+        Ok(())
+    }
 }


### PR DESCRIPTION
https://github.com/paritytech/wasm-instrument/issues/3#issuecomment-1289350699

`wasm_translate.rs` was initially copied from https://github.com/bytecodealliance/wasm-tools/blob/main/crates/wasm-mutate/src/mutators/translate.rs
and murdered after that

there is many things to be redone properly, but general direction (is quite straightforward) will probably remain similar

main pain-points:
* poor api for mutating builder
* todos in `parse` func (mostly because of wasm components or non-standard wasm features)
* not finalized translation in some cases (like `Translator::const_expr` & `ConstExprKind`)